### PR TITLE
Adding ability to custom sort/filter social metrics dashboard query

### DIFF
--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -191,7 +191,7 @@ class SocialMetricsTable extends WP_List_Table {
 		
 		// CLEANED UP BY RACHEL
 		$querydata = new WP_Query(array(
-			'smt_query'		=> true,
+			'smt_query'		=> true, // is important for filtering/sorting
 			'posts_per_page'=> $limit,
 			'post_status'	=> 'publish',
 			'post_type'		=> $post_types

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -270,7 +270,7 @@ class SocialMetricsTable extends WP_List_Table {
 					<?php 
 					
 					// ADDED BY RACHEL
-					do_action( 'wpsf_restrict_manage_social_metrics_dashboard' );
+					do_action( 'smt_restrict_manage_social_metrics_dashboard' );
 					
 					?>
 

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -270,7 +270,7 @@ class SocialMetricsTable extends WP_List_Table {
 					<?php 
 					
 					// ADDED BY RACHEL
-					do_action( 'wpsf_restrict_manage_social_metrics' );
+					do_action( 'wpsf_restrict_manage_social_metrics_dashboard' );
 					
 					?>
 

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -193,8 +193,8 @@ class SocialMetricsTable extends WP_List_Table {
 		$querydata = new WP_Query(array(
 			'smt_query'		=> true,
 			'posts_per_page'=> $limit,
-			'post_status'   => 'publish',
-			'post_type'     => $post_types
+			'post_status'	=> 'publish',
+			'post_type'		=> $post_types
 			));
 
 		// Remove our date filter

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -314,6 +314,8 @@ class SocialMetricsTable extends WP_List_Table {
 						<option value="12"<?php if ($range == 12) echo 'selected="selected"'; ?>>Items published within 12 Months</option>
 						<option value="0"<?php if ($range == 0) echo 'selected="selected"'; ?>>Items published anytime</option>
 					</select>
+					
+					<?php do_action( 'wpsf_restrict_manage_social_metrics' ); ?>
 
 					<input type="submit" name="filter" id="submit_filter" class="button" value="Filter">
 

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -386,6 +386,9 @@ function smt_handle_dashboard_sorting( $query ) {
 		
 		}
 		
+		// filter SMT query because my custom query vars aren't being picked up
+		$query = apply_filters( 'smt_dashboard_query', $query );
+		
 	}
 
 }

--- a/smt-dashboard.php
+++ b/smt-dashboard.php
@@ -180,9 +180,6 @@ class SocialMetricsTable extends WP_List_Table {
 
 		$this->process_bulk_action();
 
-		$order = (!empty($_REQUEST['order'])) ? $_REQUEST['order'] : 'DESC'; //If no order, default
-		$orderby = (!empty($_REQUEST['orderby'])) ? $_REQUEST['orderby'] : $this->options['smt_options_default_sort_column']; //If no sort, default
-
 		// Get custom post types to display in our report.
 		$post_types = get_post_types(array('public'=>true, 'show_ui'=>true));
 		unset($post_types['page']);
@@ -191,59 +188,14 @@ class SocialMetricsTable extends WP_List_Table {
 		$limit = 30;
 
 		add_filter( 'posts_where', array($this, 'date_range_filter') );
-
-		if ($orderby == 'views') {
-			$querydata = new WP_Query(array(
-				'order'=>$order,
-				'orderby'=>'meta_value_num',
-				'meta_key'=>'ga_pageviews',
-				'posts_per_page'=>$limit,
-				'post_status'   => 'publish',
-				'post_type'     => $post_types
+		
+		// CLEANED UP BY RACHEL
+		$querydata = new WP_Query(array(
+			'smt_query'		=> true,
+			'posts_per_page'=> $limit,
+			'post_status'   => 'publish',
+			'post_type'     => $post_types
 			));
-		}
-
-		if ($orderby == 'comments') {
-			$querydata = new WP_Query(array(
-				'order'=>$order,
-				'orderby'=>'comment_count',
-				'posts_per_page'=>$limit,
-				'post_status'   => 'publish',
-				'post_type'     => $post_types
-			));
-		}
-
-		if ($orderby == 'social') {
-			$querydata = new WP_Query(array(
-				'order'=>$order,
-				'orderby'=>'meta_value_num',
-				'meta_key'=>'socialcount_TOTAL',
-				'posts_per_page'=>$limit,
-				'post_status'   => 'publish',
-				'post_type'     => $post_types
-			));
-		}
-
-		if ($orderby == 'aggregate') {
-			$querydata = new WP_Query(array(
-				'order'=>$order,
-				'orderby'=>'meta_value_num',
-				'meta_key'=>'social_aggregate_score',
-				'posts_per_page'=>$limit,
-				'post_status'   => 'publish',
-				'post_type'     => $post_types
-			));
-		}
-
-		if ($orderby == 'post_date') {
-			$querydata = new WP_Query(array(
-				'order'=>$order,
-				'orderby'=>'post_date',
-				'posts_per_page'=>$limit,
-				'post_status'   => 'publish',
-				'post_type'     => $post_types
-			));
-		}
 
 		// Remove our date filter
 		remove_filter( 'posts_where', array($this, 'date_range_filter') );
@@ -315,7 +267,12 @@ class SocialMetricsTable extends WP_List_Table {
 						<option value="0"<?php if ($range == 0) echo 'selected="selected"'; ?>>Items published anytime</option>
 					</select>
 					
-					<?php do_action( 'wpsf_restrict_manage_social_metrics' ); ?>
+					<?php 
+					
+					// ADDED BY RACHEL
+					do_action( 'wpsf_restrict_manage_social_metrics' );
+					
+					?>
 
 					<input type="submit" name="filter" id="submit_filter" class="button" value="Filter">
 
@@ -371,4 +328,66 @@ function smt_render_dashboard_view($options){
 	</div>
 	<?php
 }
+
+/**
+ * ADDED BY RACHEL
+ *
+ * This action tweaks the query to handle sorting in the dashboard.
+ */
+add_filter( 'pre_get_posts', 'smt_handle_dashboard_sorting' );
+function smt_handle_dashboard_sorting( $query ) {
+	
+	// Only filter on SMT queries
+	if ( $query->get( 'smt_query' ) === true ) {
+	
+		// get SMT options
+		$smt_options = get_option( 'smt_settings' );
+		
+		// get order
+		// this should be taken care of by default but something is interfering
+		// If no order, default is DESC
+		$query->set( 'order', ! empty( $_REQUEST[ 'order' ] ) ? $_REQUEST[ 'order' ] : 'DESC' );
+		
+		// get orderby
+		// If no sort, then get default option
+		$orderby = ! empty( $_REQUEST[ 'orderby' ] ) ? $_REQUEST[ 'orderby' ] : $smt_options[ 'smt_options_default_sort_column' ];
+				
+		// tweak query based on orderby
+		switch( $orderby ) {
+		
+			case 'aggregate':
+			
+				$query->set( 'orderby', 'meta_value_num' );
+				$query->set( 'meta_key', 'social_aggregate_score' );
+				break;
+				
+			case 'comments':
+			
+				$query->set( 'orderby', 'comment_count' );				
+				break;
+				
+			case 'post_date':
+			
+				$query->set( 'orderby', 'post_date' );			
+				break;
+				
+			case 'social':
+			
+				$query->set( 'orderby', 'meta_value_num' );
+				$query->set( 'meta_key', 'socialcount_TOTAL' );				
+				break;
+				
+			case 'views':
+			
+				$query->set( 'orderby', 'meta_value_num' );
+				$query->set( 'meta_key', 'ga_pageviews' );
+				
+				break;
+		
+		}
+		
+	}
+
+}
+
 ?>


### PR DESCRIPTION
Just wanted to show you some tweaks I made to the plugin today so I could add in my own sorting and filtering. The 'smt_restrict_manage_social_metrics_dashboard' action is the important part in order to add the HTML for filtering and then I simplifed your query in prepare_items() and moved your different sorting mechanisms to a 'pre_get_posts' hook to clean things up. I also added a filter at the end of the 'pre_get_posts' hook so I could filter the query even further with my own tweaks. Adding a 'smt_query' variable to the filter allows me to signify when a social media tracker query is happening, as opposed to any other query, for conditional sorting/filtering purposes. My name is all over the place because that's my method of discovering when I've altered someone else's code. :)
