### PR TITLE
Allowed tracking of attachments

### DIFF
--- a/src/MetricsUpdater.class.php
+++ b/src/MetricsUpdater.class.php
@@ -252,8 +252,7 @@ class MetricsUpdater {
 		if (!$post instanceof WP_Post) return false;
 
 		$permalink = ($permalink) ? $permalink : get_permalink($post_id);
-		//@todo Remove this
-		$permalink = str_replace( '.dev', '.com', $permalink );
+
 		if ($permalink === false) return false;
 
 		// Stop if TTL not elapsed

--- a/src/MetricsUpdater.class.php
+++ b/src/MetricsUpdater.class.php
@@ -180,6 +180,8 @@ class MetricsUpdater {
 			if (isset($this->smt->options['smt_options_post_types_'.$type]) && $this->smt->options['smt_options_post_types_'.$type] == $type) $types_to_track[] = $type;
 		}
 
+		$smt_post_types = apply_filters( 'smt_post_types', $smt_post_types );
+
 		// If none selected, default post types
 		return ($types_to_track) ? $types_to_track : array_values($smt_post_types);
 

--- a/src/settings/smt-general.php
+++ b/src/settings/smt-general.php
@@ -1,9 +1,9 @@
 <?php
 
-$smt_post_types = get_post_types( array('public'=>true, 'show_ui'=>true), 'names' );
-
-// Do not allow attachments
-unset($smt_post_types['attachment']);
+$smt_post_types = array();
+foreach ( get_post_types( array('public'=>true, 'show_ui'=>true), 'objects' ) as $type ) {
+	$smt_post_types[ $type->name ] = $type->labels->name;
+}
 
 global $wpsf_settings;
 

--- a/src/smt-dashboard.php
+++ b/src/smt-dashboard.php
@@ -327,7 +327,7 @@ class SocialMetricsTable extends WP_List_Table {
 		$querydata = new WP_Query(array(
 			'posts_per_page'=> $per_page,
 			'offset'        => ($this->get_pagenum()-1) * $per_page,
-			'post_status'	=> 'publish',
+			'post_status'	=> array( 'publish', 'inherit' ),
 			'post_type'		=> $post_types
 		));
 

--- a/src/social-metrics-tracker.php
+++ b/src/social-metrics-tracker.php
@@ -209,7 +209,6 @@ class SocialMetricsTracker {
 		$types_to_track = array();
 
 		$smt_post_types = get_post_types( array( 'public' => true ), 'names' );
-		unset($smt_post_types['attachment']);
 
 		foreach ($smt_post_types as $type) {
 			if (isset($this->options['smt_options_post_types_'.$type]) && $this->options['smt_options_post_types_'.$type] == $type) $types_to_track[] = $type;
@@ -271,6 +270,7 @@ class SocialMetricsTracker {
 		// Set default post types to track
 		$this->set_smt_option('post_types_post', 'post', false);
 		$this->set_smt_option('post_types_page', 'page', false);
+		$this->set_smt_option('post_types_attachment', 'page', false);
 		$this->add_missing_settings(); // Also saves the two above
 
 		$this->version_check();


### PR DESCRIPTION
I enabled the tracking of attachments. By default this is disabled in the settings. I also made some smaller changes:
- Post types on the settings screen are now listed by their name
- Checking of the post ID in `updatePostStats` is now more robust. It was causing unit test errors for me.
- Added `smt_post_types` filter to allow dynamic changing of the tracked post types 
